### PR TITLE
ci: fix Dependabot automerge workflow (gh CLI, skip if auto-merge disabled)

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -36,8 +36,9 @@ jobs:
 
       - name: Approve PR (patch or dev minor)
         if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          (steps.metadata.outputs.update-type == 'version-update:semver-minor' && steps.metadata.outputs.dependency-type == 'direct:development')
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          (steps.metadata.outputs.update-type == 'version-update:semver-minor' && steps.metadata.outputs.dependency-type == 'direct:development')) &&
+          steps.automerge_setting.outputs.allow_auto_merge == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -45,8 +46,9 @@ jobs:
 
       - name: Enable auto-merge
         if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          (steps.metadata.outputs.update-type == 'version-update:semver-minor' && steps.metadata.outputs.dependency-type == 'direct:development')
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          (steps.metadata.outputs.update-type == 'version-update:semver-minor' && steps.metadata.outputs.dependency-type == 'direct:development')) &&
+          steps.automerge_setting.outputs.allow_auto_merge == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
Replace third-party actions with gh CLI to avoid resolution errors and skip gracefully if auto-merge is disabled in repo settings.

- Use dependabot/fetch-metadata to classify updates
- Approve eligible PRs via 
  `gh pr review <number> --approve`
- Enable auto-merge via 
  `gh pr merge <number> --squash --auto`
- Early-exit if repository does not allow auto-merge

This should resolve the failing "Dependabot Auto-merge" checks on bot PRs while keeping CI, commitlint, and semantic checks stable.
