### PR TITLE
feat(walls): add wall form component

### DIFF
--- a/src/features/walls/components/WallForm/WallForm.module.css
+++ b/src/features/walls/components/WallForm/WallForm.module.css
@@ -1,0 +1,5 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}

--- a/src/features/walls/components/WallForm/WallForm.stories.tsx
+++ b/src/features/walls/components/WallForm/WallForm.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import WallForm from './WallForm';
+
+const meta: Meta<typeof WallForm> = {
+  title: 'Walls/WallForm',
+  component: WallForm,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof WallForm>;
+
+export const Default: Story = {
+  args: {
+    onSubmit: (values) => console.log(values),
+  },
+};

--- a/src/features/walls/components/WallForm/WallForm.test.tsx
+++ b/src/features/walls/components/WallForm/WallForm.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, test, expect, vi } from 'vitest';
+import WallForm from './WallForm';
+
+describe('WallForm', () => {
+  test('submits form values', () => {
+    const handleSubmit = vi.fn();
+    render(<WallForm onSubmit={handleSubmit} />);
+
+    fireEvent.change(screen.getByLabelText(/name/i), {
+      target: { value: 'Wall A' },
+    });
+    fireEvent.change(screen.getByLabelText(/length/i), {
+      target: { value: '10' },
+    });
+    fireEvent.change(screen.getByLabelText(/height/i), {
+      target: { value: '8' },
+    });
+    fireEvent.change(screen.getByLabelText(/stud spacing/i), {
+      target: { value: '24' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /save wall/i }));
+
+    expect(handleSubmit).toHaveBeenCalledWith({
+      name: 'Wall A',
+      length: 10,
+      height: 8,
+      studSpacing: '24',
+    });
+  });
+});

--- a/src/features/walls/components/WallForm/WallForm.tsx
+++ b/src/features/walls/components/WallForm/WallForm.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Button, Select, TextField } from '../../../../shared/components/Form';
+import type { WallFormValues } from '../../types/WallForm.types';
+import styles from './WallForm.module.css';
+
+interface WallFormProps {
+  initialValues?: WallFormValues;
+  onSubmit: (values: WallFormValues) => void;
+}
+
+const WallForm: React.FC<WallFormProps> = ({ initialValues, onSubmit }) => {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const data = new FormData(e.currentTarget);
+    const values: WallFormValues = {
+      name: (data.get('name') as string) || '',
+      length: Number(data.get('length')),
+      height: Number(data.get('height')),
+      studSpacing: (data.get('studSpacing') as '16' | '24') || '16',
+    };
+    onSubmit(values);
+  };
+
+  return (
+    <form className={styles.form} onSubmit={handleSubmit}>
+      <TextField label="Name" name="name" defaultValue={initialValues?.name} required />
+      <TextField
+        label="Length (ft)"
+        name="length"
+        type="number"
+        defaultValue={initialValues?.length}
+        required
+      />
+      <TextField
+        label="Height (ft)"
+        name="height"
+        type="number"
+        defaultValue={initialValues?.height}
+        required
+      />
+      <Select
+        label="Stud Spacing"
+        name="studSpacing"
+        options={[
+          { value: '16', label: '16" OC' },
+          { value: '24', label: '24" OC' },
+        ]}
+        defaultValue={initialValues?.studSpacing ?? '16'}
+      />
+      <Button type="submit" colorVariant="primary">
+        Save Wall
+      </Button>
+    </form>
+  );
+};
+
+export default WallForm;

--- a/src/features/walls/index.ts
+++ b/src/features/walls/index.ts
@@ -1,0 +1,2 @@
+export { default as WallForm } from './components/WallForm/WallForm';
+export type { WallFormValues } from './types/WallForm.types';

--- a/src/features/walls/types/WallForm.types.ts
+++ b/src/features/walls/types/WallForm.types.ts
@@ -1,0 +1,6 @@
+export interface WallFormValues {
+  name: string;
+  length: number;
+  height: number;
+  studSpacing: '16' | '24';
+}


### PR DESCRIPTION
## Summary
- scaffold WallForm component for entering basic wall properties
- export wall form types for reuse

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Host system is missing dependencies to run browsers)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b1a0c076088330acb144b9e44754fc