### PR TITLE
feat(walls): enable wall creation and management

### DIFF
--- a/src/app/store/projectStore.test.tsx
+++ b/src/app/store/projectStore.test.tsx
@@ -21,4 +21,19 @@ describe('projectStore', () => {
     expect(useProjectStore.getState().projects[created.id]).toBeUndefined();
     expect(localStorage.getItem(`framing-project-${created.id}`)).toBeNull();
   });
+
+  it('adds and removes walls from a project', async () => {
+    const project = await useProjectStore.getState().createProject('Walls');
+    const wall = await useProjectStore.getState().addWall(project.id, {
+      name: 'Wall A',
+      length: 10,
+      height: 8,
+      studSpacing: '16',
+      topPlate: 'double',
+      bottomPlate: 'standard',
+    });
+    expect(useProjectStore.getState().projects[project.id].walls).toHaveLength(1);
+    await useProjectStore.getState().removeWall(project.id, wall.id);
+    expect(useProjectStore.getState().projects[project.id].walls).toHaveLength(0);
+  });
 });

--- a/src/features/projects/components/ProjectList/ProjectList.stories.tsx
+++ b/src/features/projects/components/ProjectList/ProjectList.stories.tsx
@@ -12,8 +12,8 @@ export default meta;
 type Story = StoryObj<typeof ProjectList>;
 
 const sampleProjects: Project[] = [
-  { id: '1', name: 'Project One', createdAt: new Date().toISOString() },
-  { id: '2', name: 'Project Two', createdAt: new Date().toISOString() },
+  { id: '1', name: 'Project One', createdAt: new Date().toISOString(), walls: [] },
+  { id: '2', name: 'Project Two', createdAt: new Date().toISOString(), walls: [] },
 ];
 
 export const Default: Story = {

--- a/src/features/projects/components/ProjectList/ProjectList.test.tsx
+++ b/src/features/projects/components/ProjectList/ProjectList.test.tsx
@@ -6,7 +6,7 @@ import type { Project } from '../../../../app/store/projectStore';
 
 describe('ProjectList', () => {
   const projects: Project[] = [
-    { id: '1', name: 'Project One', createdAt: new Date().toISOString() },
+    { id: '1', name: 'Project One', createdAt: new Date().toISOString(), walls: [] },
   ];
 
   it('selects a project', () => {

--- a/src/features/walls/components/WallItem/WallItem.test.tsx
+++ b/src/features/walls/components/WallItem/WallItem.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import { describe, it, expect, vi } from 'vitest';
+import WallItem from './WallItem';
+import type { Wall } from '../../types/Wall.types';
+
+describe('WallItem', () => {
+  const wall: Wall = {
+    id: 'wall-1',
+    projectId: 'proj-1',
+    name: 'Wall A',
+    length: 10,
+    height: 8,
+    studSpacing: '16',
+    topPlate: 'double',
+    bottomPlate: 'standard',
+  };
+
+  it('renders wall info and handles removal', () => {
+    const handleRemove = vi.fn();
+    render(
+      <ChakraProvider>
+        <WallItem wall={wall} onRemove={handleRemove} />
+      </ChakraProvider>,
+    );
+    expect(screen.getByText(/wall a/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /remove/i }));
+    expect(handleRemove).toHaveBeenCalledWith('wall-1');
+  });
+});

--- a/src/features/walls/components/WallItem/WallItem.tsx
+++ b/src/features/walls/components/WallItem/WallItem.tsx
@@ -1,0 +1,27 @@
+import { Button, HStack, Box, Text } from '@chakra-ui/react';
+import type { Wall } from '../../types/Wall.types';
+
+interface WallItemProps {
+  wall: Wall;
+  onRemove?: (id: string) => void;
+}
+
+function WallItem({ wall, onRemove }: WallItemProps) {
+  return (
+    <HStack justify="space-between">
+      <Box>
+        <Text fontWeight="bold">{wall.name}</Text>
+        <Text fontSize="sm" color="gray.500">
+          {wall.length}ft × {wall.height}ft
+        </Text>
+      </Box>
+      {onRemove && (
+        <Button size="sm" colorScheme="red" onClick={() => onRemove(wall.id)}>
+          Remove
+        </Button>
+      )}
+    </HStack>
+  );
+}
+
+export default WallItem;

--- a/src/features/walls/components/WallList/WallList.test.tsx
+++ b/src/features/walls/components/WallList/WallList.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import { describe, it, expect, vi } from 'vitest';
+import WallList from './WallList';
+import type { Wall } from '../../types/Wall.types';
+
+describe('WallList', () => {
+  const walls: Wall[] = [
+    {
+      id: 'wall-1',
+      projectId: 'proj-1',
+      name: 'Wall A',
+      length: 10,
+      height: 8,
+      studSpacing: '16',
+      topPlate: 'double',
+      bottomPlate: 'standard',
+    },
+  ];
+
+  it('renders walls and handles removal', () => {
+    const handleRemove = vi.fn();
+    render(
+      <ChakraProvider>
+        <WallList walls={walls} onRemove={handleRemove} />
+      </ChakraProvider>,
+    );
+    expect(screen.getByText(/wall a/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /remove/i }));
+    expect(handleRemove).toHaveBeenCalledWith('wall-1');
+  });
+
+  it('renders nothing when no walls', () => {
+    render(
+      <ChakraProvider>
+        <WallList walls={[]} />
+      </ChakraProvider>,
+    );
+    expect(screen.queryByText(/walls/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/features/walls/components/WallList/WallList.tsx
+++ b/src/features/walls/components/WallList/WallList.tsx
@@ -1,0 +1,28 @@
+import { Box, Heading, Stack } from '@chakra-ui/react';
+import type { Wall } from '../../types/Wall.types';
+import WallItem from '../WallItem/WallItem';
+
+interface WallListProps {
+  walls: Wall[];
+  onRemove?: (id: string) => void;
+}
+
+function WallList({ walls, onRemove }: WallListProps) {
+  if (walls.length === 0) {
+    return null;
+  }
+  return (
+    <Box borderWidth="1px" borderRadius="md" p={4} mt={4}>
+      <Heading as="h2" size="md" mb={2}>
+        Walls
+      </Heading>
+      <Stack spacing={2}>
+        {walls.map((wall) => (
+          <WallItem key={wall.id} wall={wall} onRemove={onRemove} />
+        ))}
+      </Stack>
+    </Box>
+  );
+}
+
+export default WallList;

--- a/src/features/walls/hooks/useWallManager.ts
+++ b/src/features/walls/hooks/useWallManager.ts
@@ -1,0 +1,18 @@
+import { useProjectStore } from '../../../app/store/projectStore';
+import type { WallFormValues } from '../types/WallForm.types';
+import type { Wall } from '../types/Wall.types';
+
+export const useWallManager = (projectId: string) => {
+  const { projects, addWall, removeWall } = useProjectStore();
+  const walls = projects[projectId]?.walls ?? [];
+
+  const handleAdd = async (values: WallFormValues) => {
+    await addWall(projectId, values as Omit<Wall, 'id' | 'projectId'>);
+  };
+
+  const handleRemove = async (wallId: string) => {
+    await removeWall(projectId, wallId);
+  };
+
+  return { walls, addWall: handleAdd, removeWall: handleRemove };
+};

--- a/src/features/walls/index.ts
+++ b/src/features/walls/index.ts
@@ -1,2 +1,5 @@
 export { default as WallForm } from './components/WallForm/WallForm';
+export { default as WallList } from './components/WallList/WallList';
 export type { WallFormValues } from './types/WallForm.types';
+export type { Wall } from './types/Wall.types';
+export { useWallManager } from './hooks/useWallManager';

--- a/src/features/walls/types/Wall.types.ts
+++ b/src/features/walls/types/Wall.types.ts
@@ -1,0 +1,11 @@
+export interface Wall {
+  id: string;
+  projectId: string;
+  name: string;
+  length: number;
+  height: number;
+  studSpacing: '16' | '24';
+  topPlate: 'single' | 'double';
+  bottomPlate: 'standard' | 'floating' | 'pressure-treated';
+  floorGap?: number;
+}

--- a/src/routes/projects.$projectId.tsx
+++ b/src/routes/projects.$projectId.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Link } from '@tanstack/react-router';
 import { Box, Heading, Stack, Text } from '@chakra-ui/react';
 import { useEffect } from 'react';
 import { useProjectStore } from '../app/store/projectStore';
+import { WallForm, WallList, useWallManager } from '../features/walls';
 
 export const Route = createFileRoute('/projects/$projectId')({
   component: ProjectDetail,
@@ -10,8 +11,8 @@ export const Route = createFileRoute('/projects/$projectId')({
 function ProjectDetail() {
   const { projectId } = Route.useParams();
   const { projects, loadProjects } = useProjectStore();
-
   const project = projects[projectId];
+  const { walls, addWall, removeWall } = useWallManager(projectId);
 
   useEffect(() => {
     if (!project) {
@@ -35,6 +36,10 @@ function ProjectDetail() {
         <Text>Project ID: {projectId}</Text>
         <Link to="/projects">Back to projects</Link>
       </Stack>
+      <Box mt={4}>
+        <WallForm onSubmit={(values) => void addWall(values)} />
+        <WallList walls={walls} onRemove={(id) => void removeWall(id)} />
+      </Box>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- store walls per project with add/remove actions
- add WallList and WallItem components with hook for wall management
- expose wall creation on project details page

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b31905f10c8330932dfc3189a9e26c