### PR TITLE
feat(walls): enable wall creation and management

### DIFF
--- a/src/app/store/projectStore.test.tsx
+++ b/src/app/store/projectStore.test.tsx
@@ -21,4 +21,19 @@ describe('projectStore', () => {
     expect(useProjectStore.getState().projects[created.id]).toBeUndefined();
     expect(localStorage.getItem(`framing-project-${created.id}`)).toBeNull();
   });
+
+  it('adds and removes walls from a project', async () => {
+    const project = await useProjectStore.getState().createProject('Walls');
+    const wall = await useProjectStore.getState().addWall(project.id, {
+      name: 'Wall A',
+      length: 10,
+      height: 8,
+      studSpacing: '16',
+      topPlate: 'double',
+      bottomPlate: 'standard',
+    });
+    expect(useProjectStore.getState().projects[project.id].walls).toHaveLength(1);
+    await useProjectStore.getState().removeWall(project.id, wall.id);
+    expect(useProjectStore.getState().projects[project.id].walls).toHaveLength(0);
+  });
 });

--- a/src/app/store/projectStore.ts
+++ b/src/app/store/projectStore.ts
@@ -3,11 +3,13 @@ import {
   PROJECT_STORAGE_PREFIX,
   localStorageAdapter,
 } from '../../shared/utils/persistence/localStorage.adapter';
+import type { Wall, WallInput } from '../../features/walls/types/Wall.types';
 
 export interface Project {
   id: string;
   name: string;
   createdAt: string;
+  walls: Wall[];
 }
 
 interface ProjectState {
@@ -16,6 +18,8 @@ interface ProjectState {
   createProject: (name: string) => Promise<Project>;
   deleteProject: (id: string) => Promise<void>;
   getProject: (id: string) => Project | undefined;
+  addWall: (projectId: string, wall: WallInput) => Promise<Wall>;
+  removeWall: (projectId: string, wallId: string) => Promise<void>;
 }
 
 export const useProjectStore = create<ProjectState>((set, get) => ({
@@ -27,7 +31,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       try {
         const project = (await localStorageAdapter.load(key)) as Project | null;
         if (project) {
-          projects[project.id] = project;
+          projects[project.id] = { ...project, walls: project.walls ?? [] };
         }
       } catch {
         /* ignore invalid entries */
@@ -41,6 +45,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       id,
       name,
       createdAt: new Date().toISOString(),
+      walls: [],
     };
     await localStorageAdapter.save(`${PROJECT_STORAGE_PREFIX}${id}`, project);
     set((state) => ({ projects: { ...state.projects, [id]: project } }));
@@ -55,4 +60,35 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     });
   },
   getProject: (id) => get().projects[id],
+  addWall: async (projectId, wallData) => {
+    const project = get().projects[projectId];
+    if (!project) {
+      throw new Error('Project not found');
+    }
+    const id = globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
+    const wall: Wall = { id, projectId, ...wallData };
+    const updatedProject: Project = {
+      ...project,
+      walls: [...project.walls, wall],
+    };
+    await localStorageAdapter.save(`${PROJECT_STORAGE_PREFIX}${projectId}`, updatedProject);
+    set((state) => ({
+      projects: { ...state.projects, [projectId]: updatedProject },
+    }));
+    return wall;
+  },
+  removeWall: async (projectId, wallId) => {
+    const project = get().projects[projectId];
+    if (!project) {
+      return;
+    }
+    const updatedProject: Project = {
+      ...project,
+      walls: project.walls.filter((w) => w.id !== wallId),
+    };
+    await localStorageAdapter.save(`${PROJECT_STORAGE_PREFIX}${projectId}`, updatedProject);
+    set((state) => ({
+      projects: { ...state.projects, [projectId]: updatedProject },
+    }));
+  },
 }));

--- a/src/features/projects/components/ProjectList/ProjectList.stories.tsx
+++ b/src/features/projects/components/ProjectList/ProjectList.stories.tsx
@@ -12,8 +12,8 @@ export default meta;
 type Story = StoryObj<typeof ProjectList>;
 
 const sampleProjects: Project[] = [
-  { id: '1', name: 'Project One', createdAt: new Date().toISOString() },
-  { id: '2', name: 'Project Two', createdAt: new Date().toISOString() },
+  { id: '1', name: 'Project One', createdAt: new Date().toISOString(), walls: [] },
+  { id: '2', name: 'Project Two', createdAt: new Date().toISOString(), walls: [] },
 ];
 
 export const Default: Story = {

--- a/src/features/projects/components/ProjectList/ProjectList.test.tsx
+++ b/src/features/projects/components/ProjectList/ProjectList.test.tsx
@@ -6,7 +6,7 @@ import type { Project } from '../../../../app/store/projectStore';
 
 describe('ProjectList', () => {
   const projects: Project[] = [
-    { id: '1', name: 'Project One', createdAt: new Date().toISOString() },
+    { id: '1', name: 'Project One', createdAt: new Date().toISOString(), walls: [] },
   ];
 
   it('selects a project', () => {

--- a/src/features/walls/components/WallItem/WallItem.stories.tsx
+++ b/src/features/walls/components/WallItem/WallItem.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import WallItem from './WallItem';
+import type { Wall } from '../../types/Wall.types';
+
+const meta: Meta<typeof WallItem> = {
+  title: 'Walls/WallItem',
+  component: WallItem,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof WallItem>;
+
+const sampleWall: Wall = {
+  id: 'wall-1',
+  projectId: 'proj-1',
+  name: 'Sample Wall',
+  length: 12,
+  height: 8,
+  studSpacing: '16',
+  topPlate: 'double',
+  bottomPlate: 'standard',
+};
+
+export const Default: Story = {
+  args: {
+    wall: sampleWall,
+  },
+};
+
+export const WithRemove: Story = {
+  args: {
+    wall: sampleWall,
+    onRemove: () => {},
+  },
+};

--- a/src/features/walls/components/WallItem/WallItem.test.tsx
+++ b/src/features/walls/components/WallItem/WallItem.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import { describe, it, expect, vi } from 'vitest';
+import WallItem from './WallItem';
+import type { Wall } from '../../types/Wall.types';
+
+describe('WallItem', () => {
+  const wall: Wall = {
+    id: 'wall-1',
+    projectId: 'proj-1',
+    name: 'Wall A',
+    length: 10,
+    height: 8,
+    studSpacing: '16',
+    topPlate: 'double',
+    bottomPlate: 'standard',
+  };
+
+  it('renders wall info and handles removal', () => {
+    const handleRemove = vi.fn();
+    render(
+      <ChakraProvider>
+        <WallItem wall={wall} onRemove={handleRemove} />
+      </ChakraProvider>,
+    );
+    expect(screen.getByText(/wall a/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /remove/i }));
+    expect(handleRemove).toHaveBeenCalledWith('wall-1');
+  });
+});

--- a/src/features/walls/components/WallItem/WallItem.tsx
+++ b/src/features/walls/components/WallItem/WallItem.tsx
@@ -1,0 +1,27 @@
+import { Button, HStack, Box, Text } from '@chakra-ui/react';
+import type { Wall } from '../../types/Wall.types';
+
+interface WallItemProps {
+  wall: Wall;
+  onRemove?: (id: string) => void;
+}
+
+function WallItem({ wall, onRemove }: WallItemProps) {
+  return (
+    <HStack justify="space-between">
+      <Box>
+        <Text fontWeight="bold">{wall.name}</Text>
+        <Text fontSize="sm" color="gray.500">
+          {wall.length}ft × {wall.height}ft
+        </Text>
+      </Box>
+      {onRemove && (
+        <Button size="sm" colorScheme="red" onClick={() => onRemove(wall.id)}>
+          Remove
+        </Button>
+      )}
+    </HStack>
+  );
+}
+
+export default WallItem;

--- a/src/features/walls/components/WallList/WallList.stories.tsx
+++ b/src/features/walls/components/WallList/WallList.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import WallList from './WallList';
+import type { Wall } from '../../types/Wall.types';
+
+const meta: Meta<typeof WallList> = {
+  title: 'Walls/WallList',
+  component: WallList,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof WallList>;
+
+const walls: Wall[] = [
+  {
+    id: 'wall-1',
+    projectId: 'proj-1',
+    name: 'Wall A',
+    length: 10,
+    height: 8,
+    studSpacing: '16',
+    topPlate: 'double',
+    bottomPlate: 'standard',
+  },
+  {
+    id: 'wall-2',
+    projectId: 'proj-1',
+    name: 'Wall B',
+    length: 12,
+    height: 9,
+    studSpacing: '24',
+    topPlate: 'single',
+    bottomPlate: 'floating',
+    floorGap: 1,
+  },
+];
+
+export const Default: Story = {
+  args: {
+    walls,
+  },
+};
+
+export const WithRemove: Story = {
+  args: {
+    walls,
+    onRemove: () => {},
+  },
+};

--- a/src/features/walls/components/WallList/WallList.test.tsx
+++ b/src/features/walls/components/WallList/WallList.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import { describe, it, expect, vi } from 'vitest';
+import WallList from './WallList';
+import type { Wall } from '../../types/Wall.types';
+
+describe('WallList', () => {
+  const walls: Wall[] = [
+    {
+      id: 'wall-1',
+      projectId: 'proj-1',
+      name: 'Wall A',
+      length: 10,
+      height: 8,
+      studSpacing: '16',
+      topPlate: 'double',
+      bottomPlate: 'standard',
+    },
+  ];
+
+  it('renders walls and handles removal', () => {
+    const handleRemove = vi.fn();
+    render(
+      <ChakraProvider>
+        <WallList walls={walls} onRemove={handleRemove} />
+      </ChakraProvider>,
+    );
+    expect(screen.getByText(/wall a/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /remove/i }));
+    expect(handleRemove).toHaveBeenCalledWith('wall-1');
+  });
+
+  it('renders nothing when no walls', () => {
+    render(
+      <ChakraProvider>
+        <WallList walls={[]} />
+      </ChakraProvider>,
+    );
+    expect(screen.queryByText(/walls/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/features/walls/components/WallList/WallList.tsx
+++ b/src/features/walls/components/WallList/WallList.tsx
@@ -1,0 +1,28 @@
+import { Box, Heading, Stack } from '@chakra-ui/react';
+import type { Wall } from '../../types/Wall.types';
+import WallItem from '../WallItem/WallItem';
+
+interface WallListProps {
+  walls: Wall[];
+  onRemove?: (id: string) => void;
+}
+
+function WallList({ walls, onRemove }: WallListProps) {
+  if (walls.length === 0) {
+    return null;
+  }
+  return (
+    <Box borderWidth="1px" borderRadius="md" p={4} mt={4}>
+      <Heading as="h2" size="md" mb={2}>
+        Walls
+      </Heading>
+      <Stack spacing={2}>
+        {walls.map((wall) => (
+          <WallItem key={wall.id} wall={wall} onRemove={onRemove} />
+        ))}
+      </Stack>
+    </Box>
+  );
+}
+
+export default WallList;

--- a/src/features/walls/hooks/useWallManager.test.tsx
+++ b/src/features/walls/hooks/useWallManager.test.tsx
@@ -1,0 +1,36 @@
+import { renderHook, act } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useWallManager } from './useWallManager';
+import { useProjectStore } from '../../../app/store/projectStore';
+
+describe('useWallManager', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useProjectStore.setState({ projects: {} });
+  });
+
+  it('adds and removes walls', async () => {
+    const project = await useProjectStore.getState().createProject('Walls');
+    const { result } = renderHook(() => useWallManager(project.id));
+
+    await act(async () => {
+      await result.current.addWall({
+        name: 'Wall A',
+        length: 10,
+        height: 8,
+        studSpacing: '16',
+        topPlate: 'double',
+        bottomPlate: 'standard',
+      });
+    });
+
+    expect(result.current.walls).toHaveLength(1);
+    const wallId = result.current.walls[0].id;
+
+    await act(async () => {
+      await result.current.removeWall(wallId);
+    });
+
+    expect(result.current.walls).toHaveLength(0);
+  });
+});

--- a/src/features/walls/hooks/useWallManager.ts
+++ b/src/features/walls/hooks/useWallManager.ts
@@ -1,0 +1,17 @@
+import { useProjectStore } from '../../../app/store/projectStore';
+import type { WallFormValues } from '../types/WallForm.types';
+
+export const useWallManager = (projectId: string) => {
+  const { projects, addWall, removeWall } = useProjectStore();
+  const walls = projects[projectId]?.walls ?? [];
+
+  const handleAdd = async (values: WallFormValues) => {
+    await addWall(projectId, values);
+  };
+
+  const handleRemove = async (wallId: string) => {
+    await removeWall(projectId, wallId);
+  };
+
+  return { walls, addWall: handleAdd, removeWall: handleRemove };
+};

--- a/src/features/walls/index.ts
+++ b/src/features/walls/index.ts
@@ -1,2 +1,5 @@
 export { default as WallForm } from './components/WallForm/WallForm';
+export { default as WallList } from './components/WallList/WallList';
 export type { WallFormValues } from './types/WallForm.types';
+export type { Wall, WallInput } from './types/Wall.types';
+export { useWallManager } from './hooks/useWallManager';

--- a/src/features/walls/types/Wall.types.ts
+++ b/src/features/walls/types/Wall.types.ts
@@ -1,0 +1,16 @@
+export interface WallSpecs {
+  name: string;
+  length: number;
+  height: number;
+  studSpacing: '16' | '24';
+  topPlate: 'single' | 'double';
+  bottomPlate: 'standard' | 'floating' | 'pressure-treated';
+  floorGap?: number;
+}
+
+export interface Wall extends WallSpecs {
+  id: string;
+  projectId: string;
+}
+
+export type WallInput = WallSpecs;

--- a/src/features/walls/types/WallForm.types.ts
+++ b/src/features/walls/types/WallForm.types.ts
@@ -1,9 +1,3 @@
-export interface WallFormValues {
-  name: string;
-  length: number;
-  height: number;
-  studSpacing: '16' | '24';
-  topPlate: 'single' | 'double';
-  bottomPlate: 'standard' | 'floating' | 'pressure-treated';
-  floorGap?: number;
-}
+import type { WallInput } from './Wall.types';
+
+export type WallFormValues = WallInput;

--- a/src/routes/projects.$projectId.tsx
+++ b/src/routes/projects.$projectId.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Link } from '@tanstack/react-router';
 import { Box, Heading, Stack, Text } from '@chakra-ui/react';
 import { useEffect } from 'react';
 import { useProjectStore } from '../app/store/projectStore';
+import { WallForm, WallList, useWallManager } from '../features/walls';
 
 export const Route = createFileRoute('/projects/$projectId')({
   component: ProjectDetail,
@@ -10,8 +11,8 @@ export const Route = createFileRoute('/projects/$projectId')({
 function ProjectDetail() {
   const { projectId } = Route.useParams();
   const { projects, loadProjects } = useProjectStore();
-
   const project = projects[projectId];
+  const { walls, addWall, removeWall } = useWallManager(projectId);
 
   useEffect(() => {
     if (!project) {
@@ -35,6 +36,10 @@ function ProjectDetail() {
         <Text>Project ID: {projectId}</Text>
         <Link to="/projects">Back to projects</Link>
       </Stack>
+      <Box mt={4}>
+        <WallForm onSubmit={(values) => void addWall(values)} />
+        <WallList walls={walls} onRemove={(id) => void removeWall(id)} />
+      </Box>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- store walls per project with add/remove actions
- add WallList and WallItem components with hook for wall management
- expose wall creation on project details page
- add storybook entries and unify wall types for reuse

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b31905f10c8330932dfc3189a9e26c