### PR TITLE
feat(projects): add modal flows and summary

### DIFF
--- a/src/features/projects/components/ProjectCard/ProjectCard.stories.tsx
+++ b/src/features/projects/components/ProjectCard/ProjectCard.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import ProjectCard from './ProjectCard';
+import type { Project } from '../../../../app/store/projectStore';
+
+const project: Project = {
+  id: '1',
+  name: 'Sample Project',
+  createdAt: new Date().toISOString(),
+  walls: [
+    {
+      id: 'w1',
+      projectId: '1',
+      name: 'Wall A',
+      length: 10,
+      height: 8,
+      studSpacing: '16',
+      topPlate: 'double',
+      bottomPlate: 'standard',
+    },
+  ],
+};
+
+const meta: Meta<typeof ProjectCard> = {
+  title: 'Projects/ProjectCard',
+  component: ProjectCard,
+  args: { project },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ProjectCard>;
+
+export const Default: Story = {
+  args: {
+    onSelect: () => {},
+  },
+};

--- a/src/features/projects/components/ProjectCard/ProjectCard.test.tsx
+++ b/src/features/projects/components/ProjectCard/ProjectCard.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import { describe, it, expect, vi } from 'vitest';
+import ProjectCard from './ProjectCard';
+import type { Project } from '../../../../app/store/projectStore';
+
+const project: Project = {
+  id: '1',
+  name: 'Test Project',
+  createdAt: new Date().toISOString(),
+  walls: [
+    {
+      id: 'w1',
+      projectId: '1',
+      name: 'Wall',
+      length: 12,
+      height: 8,
+      studSpacing: '16',
+      topPlate: 'double',
+      bottomPlate: 'standard',
+    },
+  ],
+};
+
+describe('ProjectCard', () => {
+  it('shows project metrics and handles actions', () => {
+    const handleSelect = vi.fn();
+    const handleDelete = vi.fn();
+    render(
+      <ChakraProvider>
+        <ProjectCard project={project} onSelect={handleSelect} onDelete={handleDelete} />
+      </ChakraProvider>,
+    );
+
+    expect(screen.getByText(/walls: 1/i)).toBeInTheDocument();
+    expect(screen.getByText(/linear ft: 12/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /test project/i }));
+    expect(handleSelect).toHaveBeenCalledWith(project);
+
+    fireEvent.click(screen.getByRole('button', { name: /delete project/i }));
+    expect(handleDelete).toHaveBeenCalledWith('1');
+  });
+});

--- a/src/features/projects/components/ProjectCard/ProjectCard.tsx
+++ b/src/features/projects/components/ProjectCard/ProjectCard.tsx
@@ -1,0 +1,46 @@
+import { Box, Button, Heading, HStack, IconButton, Stack, Text } from '@chakra-ui/react';
+import { DeleteIcon } from '@chakra-ui/icons';
+import type { Project } from '../../../../app/store/projectStore';
+
+interface ProjectCardProps {
+  project: Project;
+  onSelect?: (project: Project) => void;
+  onDelete?: (id: string) => void;
+}
+
+function ProjectCard({ project, onSelect, onDelete }: ProjectCardProps) {
+  const wallCount = project.walls.length;
+  const totalLength = project.walls.reduce((sum, w) => sum + w.length, 0);
+
+  return (
+    <Box borderWidth="1px" borderRadius="md" p={4}>
+      <Stack spacing={2}>
+        <Heading as="h3" size="md">
+          {project.name}
+        </Heading>
+        <HStack spacing={4} fontSize="sm">
+          <Text>Walls: {wallCount}</Text>
+          <Text>Linear ft: {totalLength.toFixed(2)}</Text>
+        </HStack>
+        <HStack>
+          <Button size="sm" onClick={() => onSelect?.(project)}>
+            {project.name}
+          </Button>
+          {onDelete && (
+            <IconButton
+              aria-label="Delete project"
+              icon={<DeleteIcon />}
+              size="sm"
+              onClick={() => onDelete(project.id)}
+            />
+          )}
+        </HStack>
+        <Text fontSize="xs" color="gray.500">
+          Created {new Date(project.createdAt).toLocaleDateString()}
+        </Text>
+      </Stack>
+    </Box>
+  );
+}
+
+export default ProjectCard;

--- a/src/features/projects/components/ProjectForm/ProjectForm.tsx
+++ b/src/features/projects/components/ProjectForm/ProjectForm.tsx
@@ -1,5 +1,5 @@
-import { Box, Button, Heading, Input, Stack } from '@chakra-ui/react';
-import { useState } from 'react';
+import { Button, Input, Stack } from '@chakra-ui/react';
+import { useState, type FormEvent } from 'react';
 
 interface ProjectFormProps {
   onSubmit: (name: string) => void;
@@ -8,23 +8,21 @@ interface ProjectFormProps {
 function ProjectForm({ onSubmit }: ProjectFormProps) {
   const [name, setName] = useState('');
 
-  const handleSubmit = () => {
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
     onSubmit(name.trim() || 'Untitled Project');
     setName('');
   };
 
   return (
-    <Box borderWidth="1px" borderRadius="md" p={4} mb={4}>
-      <Heading as="h2" size="md" mb={2}>
-        Create a New Project
-      </Heading>
+    <form onSubmit={handleSubmit}>
       <Stack direction={{ base: 'column', md: 'row' }} spacing={2}>
         <Input placeholder="Project name" value={name} onChange={(e) => setName(e.target.value)} />
-        <Button onClick={handleSubmit} colorScheme="teal">
+        <Button type="submit" colorScheme="teal">
           Create
         </Button>
       </Stack>
-    </Box>
+    </form>
   );
 }
 

--- a/src/features/projects/components/ProjectList/ProjectList.tsx
+++ b/src/features/projects/components/ProjectList/ProjectList.tsx
@@ -1,6 +1,6 @@
-import { Box, Button, Heading, HStack, IconButton, Stack, Text } from '@chakra-ui/react';
-import { DeleteIcon } from '@chakra-ui/icons';
+import { Box, Heading, SimpleGrid } from '@chakra-ui/react';
 import type { Project } from '../../../../app/store/projectStore';
+import ProjectCard from '../ProjectCard/ProjectCard';
 
 interface ProjectListProps {
   projects: Project[];
@@ -12,31 +12,14 @@ interface ProjectListProps {
 function ProjectList({ projects, onSelect, onDelete, title = 'Your Projects' }: ProjectListProps) {
   return (
     <Box borderWidth="1px" borderRadius="md" p={4}>
-      <Heading as="h2" size="md" mb={2}>
+      <Heading as="h2" size="md" mb={4}>
         {title}
       </Heading>
-      <Stack spacing={2}>
+      <SimpleGrid spacing={4} minChildWidth="250px">
         {projects.map((project) => (
-          <HStack key={project.id} justify="space-between">
-            <Button variant="link" onClick={() => onSelect?.(project)}>
-              {project.name}
-            </Button>
-            <HStack>
-              <Text fontSize="sm" color="gray.500">
-                {new Date(project.createdAt).toLocaleDateString()}
-              </Text>
-              {onDelete && (
-                <IconButton
-                  aria-label="Delete project"
-                  icon={<DeleteIcon />}
-                  size="sm"
-                  onClick={() => onDelete(project.id)}
-                />
-              )}
-            </HStack>
-          </HStack>
+          <ProjectCard key={project.id} project={project} onSelect={onSelect} onDelete={onDelete} />
         ))}
-      </Stack>
+      </SimpleGrid>
     </Box>
   );
 }

--- a/src/features/projects/components/ProjectSummary/ProjectSummary.stories.tsx
+++ b/src/features/projects/components/ProjectSummary/ProjectSummary.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import ProjectSummary from './ProjectSummary';
+import type { Project } from '../../../../app/store/projectStore';
+
+const project: Project = {
+  id: '1',
+  name: 'Demo Project',
+  createdAt: new Date().toISOString(),
+  walls: [
+    {
+      id: 'w1',
+      projectId: '1',
+      name: 'Wall A',
+      length: 10,
+      height: 8,
+      studSpacing: '16',
+      topPlate: 'double',
+      bottomPlate: 'standard',
+    },
+    {
+      id: 'w2',
+      projectId: '1',
+      name: 'Wall B',
+      length: 8,
+      height: 8,
+      studSpacing: '16',
+      topPlate: 'double',
+      bottomPlate: 'standard',
+    },
+  ],
+};
+
+const meta: Meta<typeof ProjectSummary> = {
+  title: 'Projects/ProjectSummary',
+  component: ProjectSummary,
+  args: { project },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ProjectSummary>;
+
+export const Default: Story = {};

--- a/src/features/projects/components/ProjectSummary/ProjectSummary.test.tsx
+++ b/src/features/projects/components/ProjectSummary/ProjectSummary.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import { describe, it, expect } from 'vitest';
+import ProjectSummary from './ProjectSummary';
+import type { Project } from '../../../../app/store/projectStore';
+
+const project: Project = {
+  id: '1',
+  name: 'Demo',
+  createdAt: new Date().toISOString(),
+  walls: [
+    {
+      id: 'w1',
+      projectId: '1',
+      name: 'A',
+      length: 10,
+      height: 8,
+      studSpacing: '16',
+      topPlate: 'double',
+      bottomPlate: 'standard',
+    },
+    {
+      id: 'w2',
+      projectId: '1',
+      name: 'B',
+      length: 15,
+      height: 8,
+      studSpacing: '16',
+      topPlate: 'double',
+      bottomPlate: 'standard',
+    },
+  ],
+};
+
+describe('ProjectSummary', () => {
+  it('displays wall count and total length', () => {
+    render(
+      <ChakraProvider>
+        <ProjectSummary project={project} />
+      </ChakraProvider>,
+    );
+
+    expect(screen.getByText(/walls/i)).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText(/total linear ft/i)).toBeInTheDocument();
+    expect(screen.getByText('25.00')).toBeInTheDocument();
+  });
+});

--- a/src/features/projects/components/ProjectSummary/ProjectSummary.tsx
+++ b/src/features/projects/components/ProjectSummary/ProjectSummary.tsx
@@ -1,0 +1,26 @@
+import { Box, HStack, Stat, StatLabel, StatNumber } from '@chakra-ui/react';
+import type { Project } from '../../../../app/store/projectStore';
+
+interface ProjectSummaryProps {
+  project: Project;
+}
+
+function ProjectSummary({ project }: ProjectSummaryProps) {
+  const totalLength = project.walls.reduce((sum, w) => sum + w.length, 0);
+  return (
+    <Box borderWidth="1px" borderRadius="md" p={4} mb={4}>
+      <HStack spacing={8}>
+        <Stat>
+          <StatLabel>Walls</StatLabel>
+          <StatNumber>{project.walls.length}</StatNumber>
+        </Stat>
+        <Stat>
+          <StatLabel>Total Linear Ft</StatLabel>
+          <StatNumber>{totalLength.toFixed(2)}</StatNumber>
+        </Stat>
+      </HStack>
+    </Box>
+  );
+}
+
+export default ProjectSummary;

--- a/src/features/projects/index.ts
+++ b/src/features/projects/index.ts
@@ -1,2 +1,4 @@
 export { default as ProjectForm } from './components/ProjectForm/ProjectForm';
 export { default as ProjectList } from './components/ProjectList/ProjectList';
+export { default as ProjectCard } from './components/ProjectCard/ProjectCard';
+export { default as ProjectSummary } from './components/ProjectSummary/ProjectSummary';

--- a/src/routes/projects.$projectId.tsx
+++ b/src/routes/projects.$projectId.tsx
@@ -1,7 +1,20 @@
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { Box, Heading, Stack, Text } from '@chakra-ui/react';
+import {
+  Box,
+  Button,
+  Heading,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Stack,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react';
 import { useEffect } from 'react';
 import { useProjectStore } from '../app/store/projectStore';
+import { ProjectSummary } from '../features/projects';
 import { WallForm, WallList, useWallManager } from '../features/walls';
 
 export const Route = createFileRoute('/projects/$projectId')({
@@ -13,6 +26,7 @@ function ProjectDetail() {
   const { projects, loadProjects } = useProjectStore();
   const project = projects[projectId];
   const { walls, addWall, removeWall } = useWallManager(projectId);
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   useEffect(() => {
     if (!project) {
@@ -30,16 +44,25 @@ function ProjectDetail() {
 
   return (
     <Box p={4}>
-      <Stack spacing={2}>
+      <Stack spacing={4}>
         <Heading as="h1">{project.name}</Heading>
         <Text color="gray.600">Created {new Date(project.createdAt).toLocaleString()}</Text>
-        <Text>Project ID: {projectId}</Text>
+        <Button alignSelf="flex-start" colorScheme="teal" onClick={onOpen}>
+          Add Wall
+        </Button>
+        <ProjectSummary project={project} />
+        <WallList walls={walls} onRemove={(id) => void removeWall(id)} />
         <Link to="/projects">Back to projects</Link>
       </Stack>
-      <Box mt={4}>
-        <WallForm onSubmit={(values) => void addWall(values)} />
-        <WallList walls={walls} onRemove={(id) => void removeWall(id)} />
-      </Box>
+      <Modal isOpen={isOpen} onClose={onClose} size="xl" isCentered>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Add Wall</ModalHeader>
+          <ModalBody>
+            <WallForm onSubmit={(values) => void addWall(values).then(onClose)} />
+          </ModalBody>
+        </ModalContent>
+      </Modal>
     </Box>
   );
 }

--- a/src/routes/projects.tsx
+++ b/src/routes/projects.tsx
@@ -1,5 +1,15 @@
 import { createFileRoute, useNavigate, Outlet } from '@tanstack/react-router';
-import { Box, Heading } from '@chakra-ui/react';
+import {
+  Box,
+  Button,
+  Heading,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  useDisclosure,
+} from '@chakra-ui/react';
 import { useEffect } from 'react';
 import { useProjectStore } from '../app/store/projectStore';
 import { ProjectForm, ProjectList } from '../features/projects';
@@ -13,6 +23,7 @@ export const Route = createFileRoute('/projects')({
 function ProjectsPage() {
   const navigate = useNavigate();
   const { projects, loadProjects, createProject, deleteProject } = useProjectStore();
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   useEffect(() => {
     void loadProjects();
@@ -20,6 +31,7 @@ function ProjectsPage() {
 
   const handleCreate = async (name: string) => {
     const project = await createProject(name);
+    onClose();
     navigate({ to: '/projects/$projectId', params: { projectId: project.id } });
   };
 
@@ -28,7 +40,18 @@ function ProjectsPage() {
       <Heading as="h1" mb={4}>
         Projects
       </Heading>
-      <ProjectForm onSubmit={handleCreate} />
+      <Button colorScheme="teal" onClick={onOpen} mb={4}>
+        New Project
+      </Button>
+      <Modal isOpen={isOpen} onClose={onClose} isCentered>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Create Project</ModalHeader>
+          <ModalBody pb={6}>
+            <ProjectForm onSubmit={handleCreate} />
+          </ModalBody>
+        </ModalContent>
+      </Modal>
       {Object.values(projects).length > 0 && (
         <ProjectList
           projects={Object.values(projects)}


### PR DESCRIPTION
## Summary
- introduce ProjectCard and ProjectSummary components with wall metrics
- create modal-driven flows for creating projects and adding walls
- enhance project detail page with running totals and cleaner layout

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b36d5088408330a90fece55049fed1